### PR TITLE
Added new type of application: item previewer

### DIFF
--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -108,6 +108,14 @@ section.h {
   font-weight: bold;
 }
 
+#titleLink, #titleLink:visited {
+  text-decoration: none;
+  color: inherit;
+}
+#titleLink:hover {
+  text-decoration: underline;
+}
+
 #settLink {
   font-size: 10px;
   float: right;

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -10,7 +10,10 @@
 
 <body>
   <div class="bodyWrap">
-    <div class="bodyWrapTitle">Foleon dev tools<small id="settLink">settings</small></div>
+    <div class="bodyWrapTitle">
+      <a id="titleLink" href="https://github.com/idedic/foleon-dev-tools" target="blank">Foleon Dev Tools</a>
+      <small id="settLink">settings</small>
+    </div>
 
     <section id="sectionLogo">
       <div></div>
@@ -54,13 +57,14 @@
       </div>
 
       <div class="card">
-        <div class="cardTitle">Open with...</div>
+        <div class="cardTitle">Open in new tab...</div>
 
         <p>
-          <label class="lbl">Open in</label>
+          <label class="lbl">Application</label>
           <select id="owApp">
             <option value="editor" selected>editor</option>
             <option value="previewer">previewer</option>
+            <option value="item-previewer">item previewer</option>
             <option value="dashboard">dashboard</option>
           </select>
         </p>
@@ -69,11 +73,19 @@
           <select id="owEnv"></select>
         </p>
         <p>
+          <label class="lbl">Item Id</label>
+          <input id="owItemId" type="text">
+        </p>
+        <p>
+          <label class="lbl">Composition Id</label>
+          <input id="owCompositionId" type="text">
+        </p>
+        <p>
           <label class="lbl">API</label>
           <select id="owApi"></select>
         </p>
         <p class="pButton">
-          <button id="owOpen" class="bigButton">Open</button>
+          <button id="owOpen" class="bigButton">Open in new tab</button>
           <span id="owOpenMore">...</span>
           <span id="owMoreWrap" class="h">
             <span id="owMoreShowUrl">Just show the URL</span>

--- a/src/services/urls.ts
+++ b/src/services/urls.ts
@@ -55,6 +55,11 @@ export const getPreviewerFullUrl = (env: string, pubId: string, api: string) => 
   return `${getPreviewerRootUrl(env)}${path}`;
 };
 
+export const getItemPreviewerFullUrl = (env: string, itemId: string, compositionId: string, api: string, screenshotHeight = 840) => {
+  const path = `/?itemId=${itemId}&compositionId=${compositionId}&_screenshots_=1&screenheight=${screenshotHeight}&api=${api}`
+  return `${getPreviewerRootUrl(env)}${path}`;
+};
+
 // dashboard
 
 export const getDashboardRootUrl = (env: string) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export enum Env {
 export enum App {
   EDITOR = 'editor',
   PREVIEWER = 'previewer',
+  ITEM_PREVIEWER = 'item-previewer',
   DASHBOARD = 'dashboard',
 }
 

--- a/src/ui/open.ts
+++ b/src/ui/open.ts
@@ -2,13 +2,15 @@ import $ from 'cash-dom';
 
 import { lsGet, lsSet } from '../services/ls';
 import { Api, App, DIVIDER, Env, LOCALHOST, LsKeys } from '../types';
-import { getApiUrl, getDashboardFullUrl, getEditorFullUrl, getPreviewerFullUrl } from '../services/urls';
+import { getApiUrl, getDashboardFullUrl, getEditorFullUrl, getPreviewerFullUrl, getItemPreviewerFullUrl } from '../services/urls';
 import { renderOption } from './tools';
 import { additionalEnvs, apis, defaultEnvs, getInfo } from '../services/data';
 import { createTab, getActiveTab, updateTab } from '../services/chrome';
 
 const $owApp = $('#owApp');
 const $owEnv = $('#owEnv');
+const $owItemId = $('#owItemId');
+const $owCompositionId = $('#owCompositionId');
 const $owApi = $('#owApi');
 const $owOpen = $('#owOpen');
 const $owOpenMore = $('#owOpenMore');
@@ -50,6 +52,8 @@ export const initOpen = () => {
     const app = $owApp.val() as string;
     const env = $owEnv.val() as string;
     const api = $owApi.val() as string;
+    const itemId = $owItemId.val() as string;
+    const compositionId = $owCompositionId.val() as string;
 
     let url = '';
 
@@ -57,6 +61,8 @@ export const initOpen = () => {
       url = getEditorFullUrl(info, env);
     } else if (app === App.PREVIEWER) {
       url = getPreviewerFullUrl(env, info.pubId, api);
+    } else if (app === App.ITEM_PREVIEWER) {
+      url = getItemPreviewerFullUrl(env, itemId, compositionId, api);
     } else if (app === App.DASHBOARD) {
       url = getDashboardFullUrl(env);
     }
@@ -69,10 +75,22 @@ export const initOpen = () => {
   $owApp
     .on('change', () => {
       const app = $owApp.val();
-      if (app === App.EDITOR || app === App.DASHBOARD) {
-        $owApi.parent().hide();
-      } else {
-        $owApi.parent().show();
+      switch (app) {
+        case App.PREVIEWER:
+          $owItemId.parent().hide();
+          $owCompositionId.parent().hide();
+          $owApi.parent().show();
+          break;
+        case App.ITEM_PREVIEWER:
+          $owItemId.parent().show();
+          $owCompositionId.parent().show();
+          $owApi.parent().show();
+          break;
+        default:
+          $owItemId.parent().hide();
+          $owCompositionId.parent().hide();
+          $owApi.parent().hide();
+          break;
       }
     })
     .trigger('change');


### PR DESCRIPTION
Context:
   - Item previewer is used to preview the items separate from rest of the items on the page.
   - If pageId is provided as ItemId it doesn't work currently, but overlay does. I'm not sure why. Maybe the query params are different for previewing page screenshots

What changed:
 - added a link to repository on the title of extension
 - changed section name from 'Open with...' to 'Open in new tab...'
    - also changed label for application from "Open in" to "Application"
    - also changed the button label from "Open" to "Open in new tab
 - added new application type: item previewer
     - which requires addition fields `itemId` and `compositionId` to generate link
