### PR TITLE
Enable extension for all Foleon applications and add additional cloud ENVs and APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,35 +9,39 @@ The easier way to manage environments and flags.
 ### 💻 Installation and updating
 
 Load extension:
+
 - download zip and extract it **to folder**
 - open Chrome settings and click Extensions in the bottom left
 - in the Extensions tab, click on Developer mode in upper right
 - then click on Load unpacked on the upper left
 - navigate to the folder from the first step
-- *Foleon dev tools are now installed!*
+- _Foleon dev tools are now installed!_
 
 Pin extension
+
 - click on the puzzle icon in the upper right, just beside the profile icon
 - find Foleon dev tools and click on the Pin icon
-- *now you'll always see the icon*
+- _now you'll always see the icon_
 
-**Go to the Editor tab and refresh the page. Done!**
+**Open the Foleon application (Editor, Dashboard or Previewer) in the Chrome tab and refresh the page. Done!**
 
 ##### 🕹 Updating
+
 - download zip and extract it **the same folder as previous**
 
-**Go to the Editor tab and refresh the page. Done!**
+**Open the Foleon application (Editor, Dashboard or Previewer) in the Chrome tab and refresh the page. Done!**
 
 ### 🗂 "Info" section
 
-Just basic info about the open publication in the Editor: publication name,
-publication id, page id, and environment that you're currently on.
+Just basic info about currently opened application and its content: current application, publication name, publication id, page id, and environment that you're currently on.
 
-### 🗂 "Flags" section
+### 🗂 "Current environment (flags and overrides)" section
 
 You can override local storage flags here.
 
 **API**: set the API that you wish to connect Editor to.
+
+#### Editor specific flags
 
 **Dev-Preview button**: enable if you want to see the `Dev-Preview` button.
 
@@ -45,33 +49,42 @@ You can override local storage flags here.
 
 **Debugger**: enable debugger in the Editor (little worm icon and buttons on activity indicator)
 
-When you are done with the changes, please click the "Save and reload" button, because Editor needs to reload to
+When you are done with the changes, please click the "Save and reload" button, because application needs to reload to
 collect flags from local storage.
 
-Note: if you see `default` it means that there's no flag in the Editor's local storage, and it uses whatever is a default for that environment.
+Note: if you see `default` it means that there's no flag in the local storage of current application, and it uses whatever is a default for that environment.
 If you set `default` it will remove that flag from the local storage.
 
-### 🗂 "Open with..." section
+### 🗂 "Open in new tab..." section
 
-Here you can open things in a new tab. You can open the Dashboard, or based on the "Info" (section from above), you can open current publication in the Editor or Previewer.
+Here you can open things in a new tab. You can open the Dashboard, you can open current publication in the Editor or Previewer.
 
-First, you choose if you want **Editor, Previewer or Dashboard**.
+First, choose which application you want to open: **Editor, Previewer or Dashboard**. Based on selected application, different fields will appear below.
 
 If Editor:
+
 - you can choose the **environment**
-- click on the button will open the current publication and page in the chosen environment
-- keep in mind that, if that environment is not with the same API as your current, you'll need to open Foleon Dev Tools in that tab, set the API from the "Flags" section and click "Save and reload"
+  - keep in mind that, if that environment is not with the same API as your current, you'll need to open Foleon Dev Tools in that tab, set the API from the "Current tab" section and click "Save and reload"
+- you can fill in publication `id`, page `id` and overlay `id`
+  - publication `id` and page `id` are `required` so link can be successfully generated
+  - publication `id`, page `id` and overlay `id` are filled in based on data from current tab (empty if not available)
+- click on the "Open in new tab" button will open the publication in new tab (based on selected environment and filled in fields )
 
 If Previewer:
+
 - you can choose the **environment**
 - you can choose the **API** (this is not available for "editor" option because we have to set the API flag in the local storage like explained above)
+- you can fill in the publication `id`
+  - publication `id` is `required`
+  - publication `id` is filled in based on data from current tab (empty if not available)
 
 If Dashboard:
+
 - you can choose the **environment**
 
-This section will remember your preference for all fields except for publication id. That id is always the one from the editor.
+This section will remember your preference for `Application` and `Environment` fields. Data for other fields is collected from the current tab.
 
-"Open" button will open in a new tab. There's the '...' option which will expand 2 more buttons: "Open in this tab" and "Just show the url", which is useful if you need to copy the url and use it in another browser for example.
+"Open in new tab" button will open selected application in a new tab. There's the '...' option which will expand 2 more buttons: "Open in this tab" and "Just show the url", which is useful if you need to copy the url and use it in another browser for example.
 
 ### ⚙️ Settings
 
@@ -96,12 +109,12 @@ If this project grows significantly, I'll consider fancy full-fledged dev enviro
 <img src="https://i.imgur.com/fyNBqmI.png" alt="joey" width="300">
 
 ##### Usual steps:
+
 - checkout
 - `yarn`
 - all things related to the extension are in `extension` folder, except the source for the Popup
 - the source for the Popup is `typescript` in the `src` folder
 - to build it, use `yarn build` which will place a `bundle.js` in `extension/popup/bundle` which is already included in `index.html`
-- just like the installation guide above, make sure to Load unpacked the `extension` folder (or reload the extension on reload button if already loaded) and refresh the Editor tab
+- just like the installation guide above, make sure to Load unpacked the `extension` folder (or reload the extension on reload button if already loaded) and refresh the Foleon application tab
 - for debugging the Popup, right-click on Popup > Inspect
-- for debugging the Content script, find the Content script in the Editor's dev tools, Sources section
-
+- for debugging the Content script, find the Content script in the dev tools of the Foleon application tab, Sources section

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -9,7 +9,7 @@
   "permissions": ["activeTab"],
   "content_scripts": [
     {
-      "matches": ["*://*.foleon.dev/*", "*://*.foleon.com/*", "*://localhost/*"],
+      "matches": ["*://*.foleon.dev/*", "*://*.foleon.cloud/*", "*://*.foleon.com/*", "*://localhost/*"],
       "js": ["content/content.js"]
     }
   ],

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -108,6 +108,14 @@ section.h {
   font-weight: bold;
 }
 
+#titleLink, #titleLink:visited {
+  text-decoration: none;
+  color: inherit;
+}
+#titleLink:hover {
+  text-decoration: underline;
+}
+
 #settLink {
   font-size: 10px;
   float: right;

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -18,6 +18,7 @@
   --radius: 3px;
 
   --fontSize: 12px;
+  --smallFontSize: 10px;
 }
 
 *,
@@ -108,7 +109,8 @@ section.h {
   font-weight: bold;
 }
 
-#titleLink, #titleLink:visited {
+#titleLink,
+#titleLink:visited {
   text-decoration: none;
   color: inherit;
 }
@@ -147,6 +149,10 @@ section.h {
   text-transform: uppercase;
   font-weight: bold;
   border-radius: var(--radius) var(--radius) 0 0;
+}
+
+.cardSubtitle {
+  font-size: var(--smallFontSize);
 }
 
 p {

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -1,128 +1,140 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <link href="https://fonts.googleapis.com/css2?family=Fira+Sans&display=swap" rel="stylesheet" />
+    <link href="popup-switch.css" rel="stylesheet" />
+    <link href="popup.css" rel="stylesheet" />
+    <title>Foleon Dev Tools</title>
+  </head>
 
-<head>
-  <link href="https://fonts.googleapis.com/css2?family=Fira+Sans&display=swap" rel="stylesheet" />
-  <link href="popup-switch.css" rel="stylesheet" />
-  <link href="popup.css" rel="stylesheet" />
-  <title>Foleon Dev Tools</title>
-</head>
+  <body>
+    <div class="bodyWrap">
+      <div class="bodyWrapTitle">
+        <a id="titleLink" href="https://github.com/idedic/foleon-dev-tools" target="blank">Foleon Dev Tools</a>
+        <small id="settLink">settings</small>
+      </div>
 
-<body>
-  <div class="bodyWrap">
-    <div class="bodyWrapTitle">
-      <a id="titleLink" href="https://github.com/idedic/foleon-dev-tools" target="blank">Foleon Dev Tools</a>
-      <small id="settLink">settings</small>
+      <section id="sectionLogo">
+        <div></div>
+      </section>
+
+      <section id="sectionError" class="h"></section>
+
+      <section id="sectionMain" class="h">
+        <div class="card">
+          <div class="cardTitle">Info</div>
+          <p id="info"></p>
+        </div>
+
+        <div class="card">
+          <div class="cardTitle">
+            Current environment <br />
+            <span class="cardSubtitle">(flags and overrides)</span>
+          </div>
+          <p>
+            <label class="lbl">API override</label>
+            <select id="api"></select>
+          </p>
+          <p>
+            <label class="lbl">Dev-Preview btn</label>
+            <span class="onoffswitch">
+              <input id="previewBtn" type="checkbox" class="onoffswitch-checkbox" />
+              <label class="onoffswitch-label" for="previewBtn"></label>
+            </span>
+          </p>
+          <p>
+            <label class="lbl">Dev-Preview env</label>
+            <select id="previewer"></select>
+          </p>
+          <p>
+            <label class="lbl">Debugger</label>
+            <span class="onoffswitch">
+              <input id="debug" type="checkbox" class="onoffswitch-checkbox" />
+              <label class="onoffswitch-label" for="debug"></label>
+            </span>
+          </p>
+          <p class="pButton">
+            <button id="saveAndReload" class="bigButton">Save and reload</button>
+          </p>
+        </div>
+
+        <div class="card">
+          <div class="cardTitle">Open in new tab...</div>
+
+          <p>
+            <label class="lbl">Application</label>
+            <select id="owApp">
+              <option value="editor" selected>editor</option>
+              <option value="previewer">previewer</option>
+              <option value="item-previewer">item previewer</option>
+              <option value="dashboard">dashboard</option>
+            </select>
+          </p>
+          <p>
+            <label class="lbl">Environment</label>
+            <select id="owEnv"></select>
+          </p>
+          <p>
+            <label class="lbl">Publication Id *</label>
+            <input id="owPublicationId" type="text" />
+          </p>
+          <p>
+            <label class="lbl">Page Id *</label>
+            <input id="owPageId" type="text" />
+          </p>
+          <p>
+            <label class="lbl">Overlay Id</label>
+            <input id="owOverlayId" type="text" />
+          </p>
+          <p>
+            <label class="lbl">Item Id *</label>
+            <input id="owItemId" type="text" />
+          </p>
+          <p>
+            <label class="lbl">Composition Id *</label>
+            <input id="owCompositionId" type="text" />
+          </p>
+          <p>
+            <label class="lbl">API</label>
+            <select id="owApi"></select>
+          </p>
+          <p class="pButton">
+            <button id="owOpen" class="bigButton">Open in new tab</button>
+            <span id="owOpenMore">...</span>
+            <span id="owMoreWrap" class="h">
+              <span id="owMoreShowUrl">Just show the URL</span>
+              <span id="owMoreThisTab">Open in this tab</span>
+            </span>
+          </p>
+        </div>
+      </section>
+
+      <section id="sectionSettings" class="h">
+        <div class="card">
+          <div class="cardTitle">Settings</div>
+          <p>
+            <label class="lbl">Additional<br />environments</label>
+            <textarea id="settAdditionalEnvs"></textarea>
+          </p>
+          <p>
+            <label class="lbl">Editor port</label>
+            <input id="settEditorPort" type="text" />
+          </p>
+          <p>
+            <label class="lbl">Previewer port</label>
+            <input id="settPreviewerPort" type="text" />
+          </p>
+          <p>
+            <label class="lbl">Dashboard port</label>
+            <input id="settDashboardPort" type="text" />
+          </p>
+          <p class="pButton">
+            <button id="settSave" class="bigButton">Save</button>
+          </p>
+        </div>
+      </section>
     </div>
 
-    <section id="sectionLogo">
-      <div></div>
-    </section>
-
-    <section id="sectionError" class="h"></section>
-
-    <section id="sectionMain" class="h">
-      <div class="card">
-        <div class="cardTitle">Info</div>
-        <p id="info"></p>
-      </div>
-
-      <div class="card">
-        <div class="cardTitle">Flags n Overrides</div>
-        <p>
-          <label class="lbl">API</label>
-          <select id="api"></select>
-        </p>
-        <p>
-          <label class="lbl">Dev-Preview btn</label>
-          <span class="onoffswitch">
-            <input id="previewBtn" type="checkbox" class="onoffswitch-checkbox">
-            <label class="onoffswitch-label" for="previewBtn"></label>
-          </span>
-        </p>
-        <p>
-          <label class="lbl">Dev-Preview env</label>
-          <select id="previewer"></select>
-        </p>
-        <p>
-          <label class="lbl">Debugger</label>
-          <span class="onoffswitch">
-            <input id="debug" type="checkbox" class="onoffswitch-checkbox">
-            <label class="onoffswitch-label" for="debug"></label>
-          </span>
-        </p>
-        <p class="pButton">
-          <button id="saveAndReload" class="bigButton">Save and reload</button>
-        </p>
-      </div>
-
-      <div class="card">
-        <div class="cardTitle">Open in new tab...</div>
-
-        <p>
-          <label class="lbl">Application</label>
-          <select id="owApp">
-            <option value="editor" selected>editor</option>
-            <option value="previewer">previewer</option>
-            <option value="item-previewer">item previewer</option>
-            <option value="dashboard">dashboard</option>
-          </select>
-        </p>
-        <p>
-          <label class="lbl">Environment</label>
-          <select id="owEnv"></select>
-        </p>
-        <p>
-          <label class="lbl">Item Id</label>
-          <input id="owItemId" type="text">
-        </p>
-        <p>
-          <label class="lbl">Composition Id</label>
-          <input id="owCompositionId" type="text">
-        </p>
-        <p>
-          <label class="lbl">API</label>
-          <select id="owApi"></select>
-        </p>
-        <p class="pButton">
-          <button id="owOpen" class="bigButton">Open in new tab</button>
-          <span id="owOpenMore">...</span>
-          <span id="owMoreWrap" class="h">
-            <span id="owMoreShowUrl">Just show the URL</span>
-            <span id="owMoreThisTab">Open in this tab</span>
-          </span>
-        </p>
-      </div>
-    </section>
-
-    <section id="sectionSettings" class="h">
-      <div class="card">
-        <div class="cardTitle">Settings</div>
-        <p>
-          <label class="lbl">Additional<br>environments</label>
-          <textarea id="settAdditionalEnvs"></textarea>
-        </p>
-        <p>
-          <label class="lbl">Editor port</label>
-          <input id="settEditorPort" type="text" />
-        </p>
-        <p>
-          <label class="lbl">Previewer port</label>
-          <input id="settPreviewerPort" type="text" />
-        </p>
-        <p>
-          <label class="lbl">Dashboard port</label>
-          <input id="settDashboardPort" type="text" />
-        </p>
-        <p class="pButton">
-          <button id="settSave" class="bigButton">Save</button>
-        </p>
-      </div>
-    </section>
-
-  </div>
-
-  <script src="./bundle/bundle.js"></script>
-</body>
-
+    <script src="./bundle/bundle.js"></script>
+  </body>
 </html>

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -10,7 +10,10 @@
 
 <body>
   <div class="bodyWrap">
-    <div class="bodyWrapTitle">Foleon dev tools<small id="settLink">settings</small></div>
+    <div class="bodyWrapTitle">
+      <a id="titleLink" href="https://github.com/idedic/foleon-dev-tools" target="blank">Foleon Dev Tools</a>
+      <small id="settLink">settings</small>
+    </div>
 
     <section id="sectionLogo">
       <div></div>
@@ -54,13 +57,14 @@
       </div>
 
       <div class="card">
-        <div class="cardTitle">Open with...</div>
+        <div class="cardTitle">Open in new tab...</div>
 
         <p>
-          <label class="lbl">Open in</label>
+          <label class="lbl">Application</label>
           <select id="owApp">
             <option value="editor" selected>editor</option>
             <option value="previewer">previewer</option>
+            <option value="item-previewer">item previewer</option>
             <option value="dashboard">dashboard</option>
           </select>
         </p>
@@ -69,11 +73,19 @@
           <select id="owEnv"></select>
         </p>
         <p>
+          <label class="lbl">Item Id</label>
+          <input id="owItemId" type="text">
+        </p>
+        <p>
+          <label class="lbl">Composition Id</label>
+          <input id="owCompositionId" type="text">
+        </p>
+        <p>
           <label class="lbl">API</label>
           <select id="owApi"></select>
         </p>
         <p class="pButton">
-          <button id="owOpen" class="bigButton">Open</button>
+          <button id="owOpen" class="bigButton">Open in new tab</button>
           <span id="owOpenMore">...</span>
           <span id="owMoreWrap" class="h">
             <span id="owMoreShowUrl">Just show the URL</span>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foleon-dev-tools",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,37 @@
 import { getActiveTab, sendMsgToActiveTab } from './services/chrome';
 import { showErrorSection, showMainSection } from './ui/tools';
-import { flagsKeys, parseInfo, parseLsData } from './services/data';
+import { flagsKeys, localhostEditorPort, localhostDashboardPort, localhostPreviewerPort, parseInfo, parseLsData } from './services/data';
 import { initInfo } from './ui/info';
 import { initFlags } from './ui/flags';
 import { initOpen } from './ui/open';
 import { initSettings } from './ui/settings';
 
+const isUrlFoleonEditor = (url: string) => {
+  return url.includes('editor') || url.includes(`localhost:${localhostEditorPort}`);
+};
+
+const isUrlFoleonDashboard = (url: string) => {
+  return url.includes('app') || url.includes(`localhost:${localhostDashboardPort}`);
+};
+
+const isUrlFoleonPreviewer = (url: string) => {
+  return url.includes('previewer') || url.includes(`localhost:${localhostPreviewerPort}`);
+};
+
 getActiveTab((activeTab) => {
   console.log('activeTab', activeTab);
-  const info = parseInfo(activeTab);
+  parseInfo(activeTab);
 
-  if (!info.pubId || !info.pageId) {
+  const isEditor = isUrlFoleonEditor(activeTab.url);
+  const isDashboard = isUrlFoleonDashboard(activeTab.url);
+  const isPreviewer = isUrlFoleonPreviewer(activeTab.url);
+
+  const isFoleonApp = isEditor || isDashboard || isPreviewer;
+
+  if (!isFoleonApp) {
     showErrorSection([
-      "It looks like you're not in the Editor tab.",
-      'If you are sure that this is the Editor tab, please refresh the page and reopen the extension popup.',
+      "It looks like you're not in the Foleon application tab (Dashboard, Editor or Previewer).",
+      'If you are sure that this is the Foleon application tab, please refresh the page and reopen the extension popup.',
     ]);
     return;
   }
@@ -23,9 +41,10 @@ getActiveTab((activeTab) => {
     (response) => {
       parseLsData(response);
 
+      const currentApp = { isEditor, isDashboard, isPreviewer };
       try {
-        initInfo();
-        initFlags();
+        initInfo(currentApp);
+        initFlags(currentApp);
         initOpen();
         initSettings();
 
@@ -33,10 +52,10 @@ getActiveTab((activeTab) => {
       } catch (e) {
         console.error('foleonDevTools.request', e);
         showErrorSection([
-          'Something went wrong while getting the data from the Editor.',
-          'Please refresh the Editor tab and reopen the extension popup.',
+          'Something went wrong while getting the data from the Foleon application.',
+          'Please refresh current tab and reopen the extension popup.',
           '...',
-          "If you're feeling wild today, try clearing Editor's localStorage, and then refresh and reopen.",
+          "If you're feeling wild today, try clearing localStorage of the current application, and then refresh and reopen.",
           'If this keeps failing, contact the developer.',
         ]);
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,27 +6,10 @@ import { initFlags } from './ui/flags';
 import { initOpen } from './ui/open';
 import { initSettings } from './ui/settings';
 
-const isUrlFoleonEditor = (url: string) => {
-  return url.includes('editor') || url.includes(`localhost:${localhostEditorPort}`);
-};
-
-const isUrlFoleonDashboard = (url: string) => {
-  return url.includes('app') || url.includes(`localhost:${localhostDashboardPort}`);
-};
-
-const isUrlFoleonPreviewer = (url: string) => {
-  return url.includes('previewer') || url.includes(`localhost:${localhostPreviewerPort}`);
-};
-
 getActiveTab((activeTab) => {
   console.log('activeTab', activeTab);
   parseInfo(activeTab);
-
-  const isEditor = isUrlFoleonEditor(activeTab.url);
-  const isDashboard = isUrlFoleonDashboard(activeTab.url);
-  const isPreviewer = isUrlFoleonPreviewer(activeTab.url);
-
-  const isFoleonApp = isEditor || isDashboard || isPreviewer;
+  const isFoleonApp = activeTab.url.match(/\/\/(localhost:|.+foleon\.(dev|com|cloud))/);
 
   if (!isFoleonApp) {
     showErrorSection([
@@ -41,10 +24,9 @@ getActiveTab((activeTab) => {
     (response) => {
       parseLsData(response);
 
-      const currentApp = { isEditor, isDashboard, isPreviewer };
       try {
-        initInfo(currentApp);
-        initFlags(currentApp);
+        initInfo();
+        initFlags();
         initOpen();
         initSettings();
 

--- a/src/services/data.ts
+++ b/src/services/data.ts
@@ -1,4 +1,4 @@
-import { Api, DEFAULT, Env, Info, LsKeys, Tab } from '../types';
+import { Api, App, DEFAULT, Env, Info, LsKeys, Tab } from '../types';
 import { getApiUrl } from './urls';
 import { lsGet } from './ls';
 
@@ -23,14 +23,31 @@ export const apiKeys = {
     [flagsKeys.api]: 'https://api-staging.foleon.dev',
     [flagsKeys.auth]: 'https://auth-staging-dot-instant-magazine.appspot.com',
   },
+  [getApiUrl(Api.ACCEPTANCE_CLOUD)]: {
+    [flagsKeys.api]: 'https://api.acceptance.foleon.cloud',
+    [flagsKeys.auth]: 'https://auth.acceptance.foleon.cloud',
+  },
+  [getApiUrl(Api.STAGING_CLOUD)]: {
+    [flagsKeys.api]: 'https://api.staging.foleon.cloud',
+    [flagsKeys.auth]: 'https://auth.staging.foleon.cloud',
+  },
   [getApiUrl(DEFAULT)]: {
     [flagsKeys.api]: false,
     [flagsKeys.auth]: false,
   },
 };
 
-export const apis = [Api.PRODUCTION, Api.ACCEPTANCE, Api.STAGING];
-export const defaultEnvs = [Env.PRODUCTION, Env.BETA, Env.RELEASE, Env.RELEASE_BETA, Env.ACCEPTANCE, Env.STAGING];
+export const apis = [Api.PRODUCTION, Api.ACCEPTANCE, Api.STAGING, Api.ACCEPTANCE_CLOUD, Api.STAGING_CLOUD];
+export const defaultEnvs = [
+  Env.PRODUCTION,
+  Env.BETA,
+  Env.RELEASE,
+  Env.RELEASE_BETA,
+  Env.ACCEPTANCE,
+  Env.STAGING,
+  Env.ACCEPTANCE_CLOUD,
+  Env.STAGING_CLOUD,
+];
 export const additionalEnvs = lsGet(LsKeys.ADDITIONAL_ENVS) || [
   'arsenije',
   'zdravko',
@@ -53,20 +70,40 @@ let info: Info = {};
 export const parseInfo = (tab: Tab) => {
   const { url, title } = tab;
 
-  const matchLocal = url.match(/\/\/localhost:/);
-  const matchProduction = url.match(/\/\/editor\.foleon\.com\//);
-  const matchEnv = url.match(/\/\/editor-(.+)\.foleon\.dev\//);
+  const matchLocalEnv = url.match(/\/\/localhost:(\d+)/);
+  const matchProductionEnv = url.match(/\/\/(editor|previewer|dashboard)\.foleon\.com\//);
+  const matchDevEnv = url.match(/\/\/(editor|previewer|dashboard)(-(.+))?\.foleon\.dev/);
+  const matchCloudEnv = url.match(/\/\/(editor|previewer|dashboard)\.(.+)\.foleon\.cloud\//);
+
+  const checkIfFoleonApp = (app: App, localhostPort: string) => {
+    return (
+      (matchLocalEnv && matchLocalEnv[1] === localhostPort) ||
+      (matchProductionEnv && matchProductionEnv[1] === app) ||
+      (matchDevEnv && matchDevEnv[1] === app) ||
+      (matchCloudEnv && matchCloudEnv[1] === app)
+    );
+  };
 
   const matchPubId = url.match(/\/publication\/(\d+)/);
   const matchPageId = url.match(/\/pages\/(\d+)/);
   const matchOverlayId = url.match(/\/overlay\/(\d+)/);
 
+  const app = (() => {
+    if (checkIfFoleonApp(App.EDITOR, localhostEditorPort)) return App.EDITOR;
+    if (checkIfFoleonApp(App.DASHBOARD, localhostDashboardPort)) return App.DASHBOARD;
+    if (checkIfFoleonApp(App.PREVIEWER, localhostPreviewerPort)) return App.PREVIEWER;
+  })();
+
+  const env = (() => {
+    if (matchLocalEnv) return 'localhost';
+    if (matchProductionEnv) return Env.PRODUCTION;
+    if (matchDevEnv) return matchDevEnv[2];
+    if (matchCloudEnv) return `${matchCloudEnv[2]} cloud`;
+  })();
+
   info = {
-    env: (() => {
-      if (matchLocal) return 'localhost';
-      if (matchProduction) return Env.PRODUCTION;
-      if (matchEnv) return matchEnv[1];
-    })(),
+    app,
+    env,
     pubId: matchPubId && matchPubId[1],
     pageId: matchPageId && matchPageId[1],
     overlayId: matchOverlayId && matchOverlayId[1],

--- a/src/services/data.ts
+++ b/src/services/data.ts
@@ -70,7 +70,7 @@ export const parseInfo = (tab: Tab) => {
     pubId: matchPubId && matchPubId[1],
     pageId: matchPageId && matchPageId[1],
     overlayId: matchOverlayId && matchOverlayId[1],
-    title: (title || '').split(' - ')[1] || '',
+    pubName: (title || '').split(' - ')[1] || '',
   };
 
   console.log('Info', info);

--- a/src/services/data.ts
+++ b/src/services/data.ts
@@ -97,7 +97,7 @@ export const parseInfo = (tab: Tab) => {
   const env = (() => {
     if (matchLocalEnv) return 'localhost';
     if (matchProductionEnv) return Env.PRODUCTION;
-    if (matchDevEnv) return matchDevEnv[2];
+    if (matchDevEnv) return matchDevEnv[3];
     if (matchCloudEnv) return `${matchCloudEnv[2]} cloud`;
   })();
 

--- a/src/services/urls.ts
+++ b/src/services/urls.ts
@@ -24,8 +24,8 @@ export const getEditorRootUrl = (env: string) => {
   }
 };
 
-export const getEditorFullUrl = (info: Info, env: string) => {
-  const path = `/publication/${info.pubId}/pages/${info.pageId}${info.overlayId ? `/overlay/${info.overlayId}` : ''}`;
+export const getEditorFullUrl = (env: string, publicationId: string, pageId: string, overlayId?: string) => {
+  const path = `/publication/${publicationId}/pages/${pageId}${overlayId ? `/overlay/${overlayId}` : ''}`;
   return `${getEditorRootUrl(env)}${path}`;
 };
 
@@ -56,7 +56,7 @@ export const getPreviewerFullUrl = (env: string, pubId: string, api: string) => 
 };
 
 export const getItemPreviewerFullUrl = (env: string, itemId: string, compositionId: string, api: string, screenshotHeight = 840) => {
-  const path = `/?itemId=${itemId}&compositionId=${compositionId}&_screenshots_=1&screenheight=${screenshotHeight}&api=${api}`
+  const path = `/?itemId=${itemId}&compositionId=${compositionId}&_screenshots_=1&screenheight=${screenshotHeight}&api=${api}`;
   return `${getPreviewerRootUrl(env)}${path}`;
 };
 

--- a/src/services/urls.ts
+++ b/src/services/urls.ts
@@ -55,6 +55,11 @@ export const getPreviewerFullUrl = (env: string, pubId: string, api: string) => 
   return `${getPreviewerRootUrl(env)}${path}`;
 };
 
+export const getItemPreviewerFullUrl = (env: string, itemId: string, compositionId: string, api: string, screenshotHeight = 840) => {
+  const path = `/?itemId=${itemId}&compositionId=${compositionId}&_screenshots_=1&screenheight=${screenshotHeight}&api=${api}`
+  return `${getPreviewerRootUrl(env)}${path}`;
+};
+
 // dashboard
 
 export const getDashboardRootUrl = (env: string) => {

--- a/src/services/urls.ts
+++ b/src/services/urls.ts
@@ -19,6 +19,11 @@ export const getEditorRootUrl = (env: string) => {
     case Env.RELEASE_BETA:
       return `https://editor-beta.foleon.dev`;
 
+    case Env.ACCEPTANCE_CLOUD:
+      return `https://editor.acceptance.foleon.cloud`;
+    case Env.STAGING_CLOUD:
+      return `https://editor.staging.foleon.cloud`;
+
     default:
       return `https://editor-${env}.foleon.dev`;
   }
@@ -39,11 +44,18 @@ export const getPreviewerRootUrl = (env: string) => {
       return `http://localhost:${localhostPreviewerPort}`;
 
     case Env.PRODUCTION:
-    case Env.BETA:
       return `https://previewer.foleon.com`;
+    case Env.BETA:
+      return `https://previewer-beta.foleon.com`;
     case Env.RELEASE:
-    case Env.RELEASE_BETA:
       return `https://previewer.foleon.dev`;
+    case Env.RELEASE_BETA:
+      return `https://previewer-beta.foleon.dev`;
+
+    case Env.ACCEPTANCE_CLOUD:
+      return `https://previewer.acceptance.foleon.cloud`;
+    case Env.STAGING_CLOUD:
+      return `https://previewer.staging.foleon.cloud`;
 
     default:
       return `https://previewer-${env}.foleon.dev`;
@@ -78,6 +90,11 @@ export const getDashboardRootUrl = (env: string) => {
     case Env.RELEASE_BETA:
       return `https://app-beta.foleon.dev`;
 
+    case Env.ACCEPTANCE_CLOUD:
+      return `https://app.acceptance.foleon.cloud`;
+    case Env.STAGING_CLOUD:
+      return `https://app.staging.foleon.cloud`;
+
     default:
       return `https://app-${env}.foleon.dev`;
   }
@@ -93,6 +110,10 @@ export const getApiUrl = (api: string) => {
       return DEFAULT;
     case Api.PRODUCTION:
       return `https://api.foleon.com`;
+    case Api.ACCEPTANCE_CLOUD:
+      return `https://api.acceptance.foleon.cloud`;
+    case Api.STAGING_CLOUD:
+      return `https://api.staging.foleon.cloud`;
     default:
       return `https://api-${api}.foleon.dev`;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 export interface Info {
+  app?: App;
   env?: string;
   pubId?: string;
   pageId?: string;
@@ -12,7 +13,9 @@ export type UpdateProperties = chrome.tabs.UpdateProperties;
 export enum Api {
   PRODUCTION = 'production',
   ACCEPTANCE = 'acceptance',
+  ACCEPTANCE_CLOUD = 'acceptance cloud',
   STAGING = 'staging',
+  STAGING_CLOUD = 'staging cloud',
 }
 
 export enum Env {
@@ -21,7 +24,9 @@ export enum Env {
   RELEASE = 'release',
   RELEASE_BETA = 'release beta',
   ACCEPTANCE = 'acceptance',
+  ACCEPTANCE_CLOUD = 'acceptance cloud',
   STAGING = 'staging',
+  STAGING_CLOUD = 'staging cloud',
 }
 
 export enum App {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export interface Info {
   pubId?: string;
   pageId?: string;
   overlayId?: string;
-  title?: string;
+  pubName?: string;
 }
 
 export type Tab = chrome.tabs.Tab;
@@ -41,4 +41,10 @@ export enum LsKeys {
   LOCALHOST_EDITOR_PORT = 'localhostEditorPort',
   LOCALHOST_PREVIEWER_PORT = 'localhostPreviewerPort',
   LOCALHOST_DASHBOARD_PORT = 'localhostDashboardPort',
+}
+
+export interface ICurrentApp {
+  isEditor: boolean;
+  isDashboard: boolean;
+  isPreviewer: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export enum Env {
 export enum App {
   EDITOR = 'editor',
   PREVIEWER = 'previewer',
+  ITEM_PREVIEWER = 'item-previewer',
   DASHBOARD = 'dashboard',
 }
 

--- a/src/ui/flags.ts
+++ b/src/ui/flags.ts
@@ -1,9 +1,9 @@
 import $ from 'cash-dom';
 
-import { ICurrentApp, DEFAULT, DIVIDER } from '../types';
+import { ICurrentApp, DEFAULT, DIVIDER, Api, App } from '../types';
 import { renderOption } from './tools';
 import { getApiUrl, getPreviewerRootUrl } from '../services/urls';
-import { additionalEnvs, apiKeys, apis, defaultEnvs, getLsData, flagsKeys } from '../services/data';
+import { additionalEnvs, apiKeys, apis, defaultEnvs, getLsData, flagsKeys, getInfo } from '../services/data';
 import { getActiveTab, reloadTab, sendMsgToActiveTab } from '../services/chrome';
 
 const $api = $('#api');
@@ -14,7 +14,7 @@ const $saveAndReload = $('#saveAndReload');
 
 const renderApisUI = () => {
   const apisToRender = [DEFAULT, DIVIDER, ...apis];
-  const ui = apisToRender.map((env) => renderOption(env, `<option value="${getApiUrl(env)}">${env}</option>`)).join('');
+  const ui = apisToRender.map((api) => renderOption(api, `<option value="${getApiUrl(api)}">${api}</option>`)).join('');
   $api.html(ui);
 };
 
@@ -24,19 +24,20 @@ const renderPreviewerEnvsUI = () => {
   $previewer.html(ui);
 };
 
-const showOptionsBasedOnCurrentApp = (currentApp: ICurrentApp) => {
-  if (!currentApp.isEditor) {
+const showOptionsBasedOnCurrentApp = (app: App) => {
+  if (app !== App.EDITOR) {
     $previewBtn.parent().parent().hide();
     $previewer.parent().hide();
     $debug.parent().parent().hide();
   }
 };
 
-export const initFlags = (currentApp: ICurrentApp) => {
+export const initFlags = () => {
   renderApisUI();
   renderPreviewerEnvsUI();
 
-  showOptionsBasedOnCurrentApp(currentApp);
+  const info = getInfo();
+  showOptionsBasedOnCurrentApp(info.app);
 
   const lsData = getLsData();
 

--- a/src/ui/flags.ts
+++ b/src/ui/flags.ts
@@ -1,6 +1,6 @@
 import $ from 'cash-dom';
 
-import { DEFAULT, DIVIDER } from '../types';
+import { ICurrentApp, DEFAULT, DIVIDER } from '../types';
 import { renderOption } from './tools';
 import { getApiUrl, getPreviewerRootUrl } from '../services/urls';
 import { additionalEnvs, apiKeys, apis, defaultEnvs, getLsData, flagsKeys } from '../services/data';
@@ -24,9 +24,19 @@ const renderPreviewerEnvsUI = () => {
   $previewer.html(ui);
 };
 
-export const initFlags = () => {
+const showOptionsBasedOnCurrentApp = (currentApp: ICurrentApp) => {
+  if (!currentApp.isEditor) {
+    $previewBtn.parent().parent().hide();
+    $previewer.parent().hide();
+    $debug.parent().parent().hide();
+  }
+};
+
+export const initFlags = (currentApp: ICurrentApp) => {
   renderApisUI();
   renderPreviewerEnvsUI();
+
+  showOptionsBasedOnCurrentApp(currentApp);
 
   const lsData = getLsData();
 

--- a/src/ui/info.ts
+++ b/src/ui/info.ts
@@ -1,7 +1,7 @@
 import $ from 'cash-dom';
 
 import { getInfo } from '../services/data';
-import { ICurrentApp } from '../types';
+import { App, ICurrentApp } from '../types';
 
 const $info = $('#info');
 
@@ -9,15 +9,14 @@ const getApplicationName = (currentApp: ICurrentApp) => {
   return currentApp.isEditor ? 'editor' : currentApp.isDashboard ? 'dashboard' : currentApp.isPreviewer ? 'previewer' : 'unknown';
 };
 
-const renderInfoUI = (currentApp: ICurrentApp) => {
+const renderInfoUI = () => {
   const info = getInfo();
-  const currentAppName = getApplicationName(currentApp);
   const ui = `
-    <span>application:</span> ${currentAppName}<br />
+    <span>application:</span> ${info.app}<br />
+    <span>env:</span> ${info.env} <br />
     ${
-      currentApp.isEditor
+      info.app === App.EDITOR
         ? `
-          <span>env:</span> ${info.env} <br />
           <span>pub name:</span> ${info.pubName}<br />
           <span>pub id:</span> ${info.pubId} <br />
           <span>page id:</span> ${info.pageId}`
@@ -27,6 +26,6 @@ const renderInfoUI = (currentApp: ICurrentApp) => {
   $info.html(ui);
 };
 
-export const initInfo = (currentApp: ICurrentApp) => {
-  renderInfoUI(currentApp);
+export const initInfo = () => {
+  renderInfoUI();
 };

--- a/src/ui/info.ts
+++ b/src/ui/info.ts
@@ -1,28 +1,20 @@
 import $ from 'cash-dom';
 
 import { getInfo } from '../services/data';
-import { App, ICurrentApp } from '../types';
 
 const $info = $('#info');
 
-const getApplicationName = (currentApp: ICurrentApp) => {
-  return currentApp.isEditor ? 'editor' : currentApp.isDashboard ? 'dashboard' : currentApp.isPreviewer ? 'previewer' : 'unknown';
-};
+const generateInfo = (infoName: string, infoValue: string) => (infoValue ? `<span>${infoName}:</span> ${infoValue}<br />` : '');
 
 const renderInfoUI = () => {
   const info = getInfo();
+  console.log(info);
   const ui = `
-    <span>application:</span> ${info.app}<br />
-    <span>env:</span> ${info.env} <br />
-    ${
-      info.app === App.EDITOR
-        ? `
-          <span>pub name:</span> ${info.pubName}<br />
-          <span>pub id:</span> ${info.pubId} <br />
-          <span>page id:</span> ${info.pageId}`
-        : ''
-    }
-  `;
+    ${generateInfo('application', info.app)}
+    ${generateInfo('env', info.env)}
+    ${generateInfo('pub name', info.pubName)}
+    ${generateInfo('pub id', info.pubId)}
+    ${generateInfo('page id', info.pageId)}`;
   $info.html(ui);
 };
 

--- a/src/ui/info.ts
+++ b/src/ui/info.ts
@@ -1,18 +1,32 @@
 import $ from 'cash-dom';
 
 import { getInfo } from '../services/data';
+import { ICurrentApp } from '../types';
 
 const $info = $('#info');
 
-const renderInfoUI = () => {
+const getApplicationName = (currentApp: ICurrentApp) => {
+  return currentApp.isEditor ? 'editor' : currentApp.isDashboard ? 'dashboard' : currentApp.isPreviewer ? 'previewer' : 'unknown';
+};
+
+const renderInfoUI = (currentApp: ICurrentApp) => {
   const info = getInfo();
+  const currentAppName = getApplicationName(currentApp);
   const ui = `
-    ${info.title}<br>
-    <span>env:</span> ${info.env} <span>id:</span> ${info.pubId} <span>page:</span> ${info.pageId}
+    <span>application:</span> ${currentAppName}<br />
+    ${
+      currentApp.isEditor
+        ? `
+          <span>env:</span> ${info.env} <br />
+          <span>pub name:</span> ${info.pubName}<br />
+          <span>pub id:</span> ${info.pubId} <br />
+          <span>page id:</span> ${info.pageId}`
+        : ''
+    }
   `;
   $info.html(ui);
 };
 
-export const initInfo = () => {
-  renderInfoUI();
+export const initInfo = (currentApp: ICurrentApp) => {
+  renderInfoUI(currentApp);
 };

--- a/src/ui/open.ts
+++ b/src/ui/open.ts
@@ -2,13 +2,15 @@ import $ from 'cash-dom';
 
 import { lsGet, lsSet } from '../services/ls';
 import { Api, App, DIVIDER, Env, LOCALHOST, LsKeys } from '../types';
-import { getApiUrl, getDashboardFullUrl, getEditorFullUrl, getPreviewerFullUrl } from '../services/urls';
+import { getApiUrl, getDashboardFullUrl, getEditorFullUrl, getPreviewerFullUrl, getItemPreviewerFullUrl } from '../services/urls';
 import { renderOption } from './tools';
 import { additionalEnvs, apis, defaultEnvs, getInfo } from '../services/data';
 import { createTab, getActiveTab, updateTab } from '../services/chrome';
 
 const $owApp = $('#owApp');
 const $owEnv = $('#owEnv');
+const $owItemId = $('#owItemId');
+const $owCompositionId = $('#owCompositionId');
 const $owApi = $('#owApi');
 const $owOpen = $('#owOpen');
 const $owOpenMore = $('#owOpenMore');
@@ -50,6 +52,8 @@ export const initOpen = () => {
     const app = $owApp.val() as string;
     const env = $owEnv.val() as string;
     const api = $owApi.val() as string;
+    const itemId = $owItemId.val() as string;
+    const compositionId = $owCompositionId.val() as string;
 
     let url = '';
 
@@ -57,6 +61,8 @@ export const initOpen = () => {
       url = getEditorFullUrl(info, env);
     } else if (app === App.PREVIEWER) {
       url = getPreviewerFullUrl(env, info.pubId, api);
+    } else if (app === App.ITEM_PREVIEWER) {
+      url = getItemPreviewerFullUrl(env, itemId, compositionId, api);
     } else if (app === App.DASHBOARD) {
       url = getDashboardFullUrl(env);
     }
@@ -69,10 +75,22 @@ export const initOpen = () => {
   $owApp
     .on('change', () => {
       const app = $owApp.val();
-      if (app === App.EDITOR || app === App.DASHBOARD) {
-        $owApi.parent().hide();
-      } else {
-        $owApi.parent().show();
+      switch (app) {
+        case App.PREVIEWER:
+          $owItemId.parent().hide();
+          $owCompositionId.parent().hide();
+          $owApi.parent().show();
+          break;
+        case App.ITEM_PREVIEWER:
+          $owItemId.parent().show();
+          $owCompositionId.parent().show();
+          $owApi.parent().show();
+          break;
+        default:
+          $owItemId.parent().hide();
+          $owCompositionId.parent().hide();
+          $owApi.parent().hide();
+          break;
       }
     })
     .trigger('change');

--- a/src/ui/open.ts
+++ b/src/ui/open.ts
@@ -16,8 +16,10 @@ type OwData = {
 
 const hideRow = ($el: Cash) => $el.closest('p').hide();
 const showRow = ($el: Cash) => $el.closest('p').show();
+const hideRows = (rowArray: Cash[]) => rowArray.map(hideRow);
+const showRows = (rowArray: Cash[]) => rowArray.map(showRow);
 
-const getOwData = () => (lsGet(LsKeys.OW_DATA) as OwData) || {};
+const getOwData = () => (lsGet(LsKeys.OW_DATA) || {}) as OwData;
 const setOwData = (owData: OwData) => lsSet(LsKeys.OW_DATA, owData);
 
 const $owApp = $('#owApp');
@@ -49,7 +51,7 @@ const renderApisUI = () => {
 };
 
 const setOwDataUI = (info: Info) => {
-  const owData = (lsGet(LsKeys.OW_DATA) || {}) as OwData;
+  const owData = getOwData();
   $owApp.val(owData.app || App.EDITOR);
   $owEnv.val(owData.env || Env.ACCEPTANCE);
   $owPublicationId.val(info.pubId);
@@ -76,50 +78,20 @@ export const initOpen = () => {
       const app = $owApp.val();
       switch (app) {
         case App.PREVIEWER:
-          $owPageId.parent().hide();
-          $owOverlayId.parent().hide();
-          $owItemId.parent().hide();
-          $owCompositionId.parent().hide();
-
-          $owPublicationId.parent().show();
-          $owApi.parent().show();
-          showRow($owApi);
-          showRow($owPrint);
+          hideRows([$owPageId, $owOverlayId, $owItemId, $owCompositionId]);
+          showRows([$owPublicationId, $owApi, $owPrint]);
           break;
         case App.ITEM_PREVIEWER:
-          $owPublicationId.parent().hide();
-          $owPageId.parent().hide();
-          $owOverlayId.parent().hide();
-          hideRow($owApi);
-          hideRow($owPrint);
-
-          $owItemId.parent().show();
-          $owCompositionId.parent().show();
-          $owApi.parent().show();
-
+          hideRows([$owPublicationId, $owPageId, $owOverlayId, $owPrint]);
+          showRows([$owItemId, $owCompositionId, $owApi]);
           break;
         case App.EDITOR:
-          $owItemId.parent().hide();
-          $owCompositionId.parent().hide();
-          $owApi.parent().hide();
-          hideRow($owApi);
-          hideRow($owPrint);
-
-          $owPublicationId.parent().show();
-          $owPageId.parent().show();
-          $owOverlayId.parent().show();
+          hideRows([$owItemId, $owCompositionId, $owApi, $owPrint]);
+          showRows([$owPublicationId, $owPageId, $owOverlayId]);
           break;
         default:
           //DASHBOARD
-          $owItemId.parent().hide();
-          $owCompositionId.parent().hide();
-          $owApi.parent().hide();
-          hideRow($owApi);
-          hideRow($owPrint);
-
-          $owPublicationId.parent().hide();
-          $owPageId.parent().hide();
-          $owOverlayId.parent().hide();
+          hideRows([$owPageId, $owPublicationId, $owOverlayId, $owItemId, $owCompositionId, $owApi, $owPrint]);
           break;
       }
     })


### PR DESCRIPTION
### What has been done:
 - enabled extension to be usable in dashboard and previewer
     - options which are not available in other applications are now hidden
     - added 3 new text fields in `Flags and Overrides section`: publication Id, page Id, Overlay Id
 - added cloud environments and APIs
 
### Testing:
 - Test as much as possible because there are a lot of changes 😁 
 
### Notes:
 - Depends on: #2 
 - here is a [diff](https://github.com/avladisavljev/foleon-dev-tools/compare/feature/item-previewer...avladisavljev:feature/enable-extension-to-all-applications), but I would suggest testing and reviewing only this PR 