### PR TITLE
Hide unnecessary fields

### DIFF
--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -60,12 +60,7 @@
 
           <p id="owAppWrap">
             <label class="lbl">Application</label>
-            <select id="owApp">
-              <option value="editor" selected>editor</option>
-              <option value="previewer">previewer</option>
-              <option value="item-previewer">item previewer</option>
-              <option value="dashboard">dashboard</option>
-            </select>
+            <select id="owApp"></select>
           </p>
           <p>
             <label class="lbl">Environment</label>

--- a/src/services/data.ts
+++ b/src/services/data.ts
@@ -71,16 +71,16 @@ export const parseInfo = (tab: Tab) => {
   const { url, title } = tab;
 
   const matchLocalEnv = url.match(/\/\/localhost:(\d+)/);
-  const matchProductionEnv = url.match(/\/\/(editor|previewer|dashboard)\.foleon\.com\//);
-  const matchDevEnv = url.match(/\/\/(editor|previewer|dashboard)(-(.+))?\.foleon\.dev/);
-  const matchCloudEnv = url.match(/\/\/(editor|previewer|dashboard)\.(.+)\.foleon\.cloud\//);
+  const matchProductionEnv = url.match(/\/\/(editor|previewer|app)\.foleon\.com\//);
+  const matchDevEnv = url.match(/\/\/(editor|previewer|app)(-(.+))?\.foleon\.dev/);
+  const matchCloudEnv = url.match(/\/\/(editor|previewer|app)\.(.+)\.foleon\.cloud\//);
 
-  const checkIfFoleonApp = (app: App, localhostPort: string) => {
+  const checkIfFoleonApp = (applicationSubdomain: App.EDITOR | App.PREVIEWER | 'app', localhostPort: string) => {
     return (
       (matchLocalEnv && matchLocalEnv[1] === localhostPort) ||
-      (matchProductionEnv && matchProductionEnv[1] === app) ||
-      (matchDevEnv && matchDevEnv[1] === app) ||
-      (matchCloudEnv && matchCloudEnv[1] === app)
+      (matchProductionEnv && matchProductionEnv[1] === applicationSubdomain) ||
+      (matchDevEnv && matchDevEnv[1] === applicationSubdomain) ||
+      (matchCloudEnv && matchCloudEnv[1] === applicationSubdomain)
     );
   };
 
@@ -90,7 +90,7 @@ export const parseInfo = (tab: Tab) => {
 
   const app = (() => {
     if (checkIfFoleonApp(App.EDITOR, localhostEditorPort)) return App.EDITOR;
-    if (checkIfFoleonApp(App.DASHBOARD, localhostDashboardPort)) return App.DASHBOARD;
+    if (checkIfFoleonApp('app', localhostDashboardPort)) return App.DASHBOARD;
     if (checkIfFoleonApp(App.PREVIEWER, localhostPreviewerPort)) return App.PREVIEWER;
   })();
 

--- a/src/ui/info.ts
+++ b/src/ui/info.ts
@@ -4,17 +4,17 @@ import { getInfo } from '../services/data';
 
 const $info = $('#info');
 
-const generateInfo = (infoName: string, infoValue: string) => (infoValue ? `<span>${infoName}:</span> ${infoValue}<br />` : '');
+const renderInfo = (infoName: string, infoValue: string) => (infoValue ? `<span>${infoName}:</span> ${infoValue}<br />` : '');
 
 const renderInfoUI = () => {
   const info = getInfo();
   console.log(info);
   const ui = `
-    ${generateInfo('application', info.app)}
-    ${generateInfo('env', info.env)}
-    ${generateInfo('pub name', info.pubName)}
-    ${generateInfo('pub id', info.pubId)}
-    ${generateInfo('page id', info.pageId)}`;
+    ${renderInfo('application', info.app)}
+    ${renderInfo('env', info.env)}
+    ${renderInfo('pub name', info.pubName)}
+    ${renderInfo('pub id', info.pubId)}
+    ${renderInfo('page id', info.pageId)}`;
   $info.html(ui);
 };
 

--- a/src/ui/open.ts
+++ b/src/ui/open.ts
@@ -39,8 +39,27 @@ const $owMoreWrap = $('#owMoreWrap');
 const $owMoreShowUrl = $('#owMoreShowUrl');
 const $owMoreThisTab = $('#owMoreThisTab');
 
+const getAppOptions = (currentApp: App): App[] => {
+  switch (currentApp) {
+    case App.DASHBOARD:
+    case App.PREVIEWER:
+    case App.ITEM_PREVIEWER:
+      return [App.DASHBOARD];
+    default:
+      // App.EDITOR
+      return [App.EDITOR, App.PREVIEWER, App.ITEM_PREVIEWER, App.DASHBOARD];
+  }
+};
+
+const renderAppOptionsUI = (currentApp: App) => {
+  const appOptions = getAppOptions(currentApp);
+
+  const ui = appOptions.map((appOption, index) => renderOption(appOption)).join('');
+  $owApp.html(ui);
+};
+
 const renderOwEnvEnvsUI = () => {
-  const envs = [...defaultEnvs, DIVIDER, ...additionalEnvs, DIVIDER, LOCALHOST];
+  const envs: string[] = [...defaultEnvs, DIVIDER, ...additionalEnvs, DIVIDER, LOCALHOST];
   const ui = envs.map((env) => renderOption(env)).join('');
   $owEnv.html(ui);
 };
@@ -52,7 +71,9 @@ const renderApisUI = () => {
 
 const setOwDataUI = (info: Info) => {
   const owData = getOwData();
-  $owApp.val(owData.app || App.EDITOR);
+  const possibleApps = getAppOptions(info.app);
+  const firstPossibleApp = possibleApps.length > 0 && possibleApps[0];
+  $owApp.val(possibleApps.includes(info.app) ? info.app : firstPossibleApp);
   $owEnv.val(owData.env || Env.ACCEPTANCE);
   $owPublicationId.val(info.pubId);
   $owPageId.val(info.pageId);
@@ -67,10 +88,12 @@ const hideMoreWrapHandler = () => {
 };
 
 export const initOpen = () => {
+  const info = getInfo();
+
+  renderAppOptionsUI(info.app);
   renderOwEnvEnvsUI();
   renderApisUI();
 
-  const info = getInfo();
   setOwDataUI(info);
 
   $owApp
@@ -94,6 +117,10 @@ export const initOpen = () => {
           hideRows([$owPageId, $owPublicationId, $owOverlayId, $owItemId, $owCompositionId, $owApi, $owPrint]);
           break;
       }
+
+      // these fields will be hidden for now (looks like they will not be neccessary)
+      // TODO: remove these fields (from popup.html and this file) if they are not needed after some time
+      hideRows([$owPublicationId, $owPageId, $owOverlayId]);
     })
     .trigger('change');
 


### PR DESCRIPTION
### Context
 - hide unnecessary fields which are not used often

### What has been done
 - in "Open in new tab" panel fields: Publication Id, Page Id and Overlay Id are no longer visible for editor app
 - when `dashboard` or `previewer` is opened, now its only possible to select `dashboard` as application to open in new tab
 - fixed a bug where app and env would not show in Info panel for dashboard applications
