### PR TITLE
Added PR environments, fixed some bugs, removed old environments

### DIFF
--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -169,7 +169,7 @@ p {
 }
 
 #info span {
-  color: var(--light);
+  color: var(--medium);
 }
 
 .lbl {
@@ -238,7 +238,8 @@ p {
   justify-content: space-between;
 }
 
-.favRowLink, .favRowLink:visited {
+.favRowLink,
+.favRowLink:visited {
   color: var(--baseBlue);
 }
 .favRowLink:hover {

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -193,11 +193,11 @@ p {
   width: 93px;
 }
 
-#owAppWrap {
+#newTabAppWrap {
   border-bottom: 1px dashed var(--light);
   padding-bottom: var(--gutter1);
 }
-#owOpenMore {
+#newTabOpenMore {
   position: absolute;
   height: calc(100% - var(--gutter1));
   width: 32px;
@@ -211,7 +211,7 @@ p {
   text-align: center;
   cursor: pointer;
 }
-#owMoreWrap {
+#newTabMoreWrap {
   display: block;
   position: absolute;
   bottom: calc(100% - var(--gutter1) - 3px);
@@ -221,15 +221,15 @@ p {
   text-align: right;
   border-radius: var(--radius) var(--radius) 0 0;
 }
-#owMoreWrap.h {
+#newTabMoreWrap.h {
   display: none !important;
 }
-#owMoreWrap > span {
+#newTabMoreWrap > span {
   padding: var(--gutter1);
   display: block;
   cursor: pointer;
 }
-#owMoreWrap > span:hover {
+#newTabMoreWrap > span:hover {
   background-color: var(--infoBorder);
 }
 

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -58,55 +58,55 @@
         <div class="card">
           <div class="cardTitle">Open in new tab...</div>
 
-          <p id="owAppWrap">
+          <p id="newTabAppWrap">
             <label class="lbl">Application</label>
-            <select id="owApp"></select>
+            <select id="newTabApp"></select>
           </p>
           <p>
             <label class="lbl">Environment</label>
-            <select id="owEnv"></select>
+            <select id="newTabEnv"></select>
           </p>
           <p>
             <label class="lbl">PR Id *</label>
-            <input id="owPrId" type="text" />
+            <input id="newTabPrId" type="text" />
           </p>
           <p>
             <label class="lbl">Publication Id *</label>
-            <input id="owPublicationId" type="text" />
+            <input id="newTabPublicationId" type="text" />
           </p>
           <p>
             <label class="lbl">Page Id *</label>
-            <input id="owPageId" type="text" />
+            <input id="newTabPageId" type="text" />
           </p>
           <p>
             <label class="lbl">Overlay Id</label>
-            <input id="owOverlayId" type="text" />
+            <input id="newTabOverlayId" type="text" />
           </p>
           <p>
             <label class="lbl">Item Id *</label>
-            <input id="owItemId" type="text" />
+            <input id="newTabItemId" type="text" />
           </p>
           <p>
             <label class="lbl">Composition Id *</label>
-            <input id="owCompositionId" type="text" />
+            <input id="newTabCompositionId" type="text" />
           </p>
           <p>
             <label class="lbl">API</label>
-            <select id="owApi"></select>
+            <select id="newTabApi"></select>
           </p>
           <p>
             <label class="lbl">Print mode</label>
             <span class="onoffswitch">
-              <input id="owPrint" type="checkbox" class="onoffswitch-checkbox" />
-              <label class="onoffswitch-label" for="owPrint"></label>
+              <input id="newTabPrint" type="checkbox" class="onoffswitch-checkbox" />
+              <label class="onoffswitch-label" for="newTabPrint"></label>
             </span>
           </p>
           <p class="pButton">
-            <button id="owOpen" class="bigButton">Open in new tab</button>
-            <span id="owOpenMore">...</span>
-            <span id="owMoreWrap" class="h">
-              <span id="owMoreShowUrl">Just show the URL</span>
-              <span id="owMoreThisTab">Open in this tab</span>
+            <button id="newTabOpen" class="bigButton">Open in new tab</button>
+            <span id="newTabOpenMore">...</span>
+            <span id="newTabMoreWrap" class="h">
+              <span id="newTabMoreShowUrl">Just show the URL</span>
+              <span id="newTabMoreThisTab">Open in this tab</span>
             </span>
           </p>
         </div>

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -67,6 +67,10 @@
             <select id="owEnv"></select>
           </p>
           <p>
+            <label class="lbl">PR Id *</label>
+            <input id="owPrId" type="text" />
+          </p>
+          <p>
             <label class="lbl">Publication Id *</label>
             <input id="owPublicationId" type="text" />
           </p>

--- a/src/extensionFlags.ts
+++ b/src/extensionFlags.ts
@@ -1,0 +1,4 @@
+export const FLAGS = {
+  SHOW_NAMED_ENVS: false,
+  SHOW_ADDITIONAL_FIELDS: false,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { showErrorSection, showMainSection } from './ui/tools';
 import { flagsKeys, localhostEditorPort, localhostDashboardPort, localhostPreviewerPort, parseInfo, parseLsData } from './services/data';
 import { initInfo } from './ui/info';
 import { initFlags } from './ui/flags';
-import { initOpen } from './ui/open';
+import { initOpen } from './ui/newTab';
 import { initSettings } from './ui/settings';
 import { getFavData, initFavorites } from './ui/favorites';
 

--- a/src/services/data.ts
+++ b/src/services/data.ts
@@ -16,18 +16,10 @@ export const apiKeys = {
     [flagsKeys.auth]: 'https://auth.foleon.com',
   },
   [getApiUrl(Api.ACCEPTANCE)]: {
-    [flagsKeys.api]: 'https://api-acceptance.foleon.dev',
-    [flagsKeys.auth]: 'https://auth-acceptance-dot-foleon-staging.appspot.com',
-  },
-  [getApiUrl(Api.STAGING)]: {
-    [flagsKeys.api]: 'https://api-staging.foleon.dev',
-    [flagsKeys.auth]: 'https://auth-staging-dot-foleon-staging.appspot.com',
-  },
-  [getApiUrl(Api.ACCEPTANCE_CLOUD)]: {
     [flagsKeys.api]: 'https://api.acceptance.foleon.cloud',
     [flagsKeys.auth]: 'https://auth.acceptance.foleon.cloud',
   },
-  [getApiUrl(Api.STAGING_CLOUD)]: {
+  [getApiUrl(Api.STAGING)]: {
     [flagsKeys.api]: 'https://api.staging.foleon.cloud',
     [flagsKeys.auth]: 'https://auth.staging.foleon.cloud',
   },
@@ -37,17 +29,8 @@ export const apiKeys = {
   },
 };
 
-export const apis = [Api.PRODUCTION, Api.ACCEPTANCE, Api.STAGING, Api.ACCEPTANCE_CLOUD, Api.STAGING_CLOUD];
-export const defaultEnvs = [
-  Env.PRODUCTION,
-  Env.BETA,
-  Env.RELEASE,
-  Env.RELEASE_BETA,
-  Env.ACCEPTANCE,
-  Env.STAGING,
-  Env.ACCEPTANCE_CLOUD,
-  Env.STAGING_CLOUD,
-];
+export const apis = [Api.PRODUCTION, Api.ACCEPTANCE, Api.STAGING];
+export const defaultEnvs = [Env.PRODUCTION, Env.BETA, Env.RELEASE, Env.RELEASE_BETA, Env.ACCEPTANCE, Env.STAGING, Env.PR];
 export const additionalEnvs = lsGet(LsKeys.ADDITIONAL_ENVS) || [
   'arsenije',
   'zdravko',
@@ -73,6 +56,7 @@ export const parseInfo = (tab: Tab) => {
   const matchLocalEnv = url.match(/\/\/localhost:(\d+)/);
   const matchProductionEnv = url.match(/\/\/(editor|previewer|app)\.foleon\.com\//);
   const matchDevEnv = url.match(/\/\/(editor|previewer|app)(-(.+))?\.foleon\.dev/);
+  const matchPREnv = url.match(/\/\/(\d+)-(editor|previewer|app)\.qa\.staging\.foleon\.cloud\//);
   const matchCloudEnv = url.match(/\/\/(editor|previewer|app)\.(.+)\.foleon\.cloud\//);
 
   const checkIfFoleonApp = (applicationSubdomain: App.EDITOR | App.PREVIEWER | 'app', localhostPort: string) => {
@@ -80,6 +64,7 @@ export const parseInfo = (tab: Tab) => {
       (matchLocalEnv && matchLocalEnv[1] === localhostPort) ||
       (matchProductionEnv && matchProductionEnv[1] === applicationSubdomain) ||
       (matchDevEnv && matchDevEnv[1] === applicationSubdomain) ||
+      (matchPREnv && matchPREnv[2] === applicationSubdomain) ||
       (matchCloudEnv && matchCloudEnv[1] === applicationSubdomain)
     );
   };
@@ -98,12 +83,16 @@ export const parseInfo = (tab: Tab) => {
     if (matchLocalEnv) return 'localhost';
     if (matchProductionEnv) return Env.PRODUCTION;
     if (matchDevEnv) return matchDevEnv[3];
-    if (matchCloudEnv) return `${matchCloudEnv[2]} cloud`;
+    if (matchPREnv) return Env.PR;
+    if (matchCloudEnv) return matchCloudEnv[2];
   })();
+
+  const prId = matchPREnv ? matchPREnv[1] : undefined;
 
   info = {
     app,
     env,
+    prId,
     pubId: matchPubId && matchPubId[1],
     pageId: matchPageId && matchPageId[1],
     overlayId: matchOverlayId && matchOverlayId[1],

--- a/src/services/urls.ts
+++ b/src/services/urls.ts
@@ -2,8 +2,7 @@ import { Api, DEFAULT, Env, Info, LOCALHOST } from '../types';
 import { localhostDashboardPort, localhostEditorPort, localhostPreviewerPort } from './data';
 
 // editor
-
-export const getEditorRootUrl = (env: string) => {
+export const getEditorRootUrl = (env: string, prId?: string) => {
   switch (env) {
     case DEFAULT:
       return DEFAULT;
@@ -15,28 +14,23 @@ export const getEditorRootUrl = (env: string) => {
     case Env.BETA:
       return `https://editor-beta.foleon.com`;
     case Env.RELEASE:
-      return `https://editor.foleon.dev`;
+      return `https://editor-release.foleon.dev`;
     case Env.RELEASE_BETA:
       return `https://editor-beta.foleon.dev`;
-
-    case Env.ACCEPTANCE_CLOUD:
-      return `https://editor.acceptance.foleon.cloud`;
-    case Env.STAGING_CLOUD:
-      return `https://editor.staging.foleon.cloud`;
-
+    case Env.PR:
+      return `https://${prId}-editor.qa.staging.foleon.cloud`;
     default:
-      return `https://editor-${env}.foleon.dev`;
+      return `https://editor.${env}.foleon.cloud`;
   }
 };
 
-export const getEditorFullUrl = (env: string, publicationId: string, pageId: string, overlayId?: string) => {
+export const getEditorFullUrl = (env: string, publicationId: string, pageId: string, overlayId?: string, prId?: string) => {
   const path = `/publication/${publicationId}/pages/${pageId}${overlayId ? `/overlay/${overlayId}` : ''}`;
-  return `${getEditorRootUrl(env)}${path}`;
+  return `${getEditorRootUrl(env, prId)}${path}`;
 };
 
 // previewer
-
-export const getPreviewerRootUrl = (env: string) => {
+export const getPreviewerRootUrl = (env: string, prId?: string) => {
   switch (env) {
     case DEFAULT:
       return DEFAULT;
@@ -48,33 +42,28 @@ export const getPreviewerRootUrl = (env: string) => {
     case Env.BETA:
       return `https://previewer-beta.foleon.com`;
     case Env.RELEASE:
-      return `https://previewer.foleon.dev`;
+      return `https://previewer-release.foleon.dev`;
     case Env.RELEASE_BETA:
       return `https://previewer-beta.foleon.dev`;
-
-    case Env.ACCEPTANCE_CLOUD:
-      return `https://previewer.acceptance.foleon.cloud`;
-    case Env.STAGING_CLOUD:
-      return `https://previewer.staging.foleon.cloud`;
-
+    case Env.PR:
+      return `https://${prId}-previewer.qa.staging.foleon.cloud`;
     default:
-      return `https://previewer-${env}.foleon.dev`;
+      return `https://previewer.${env}.foleon.cloud`;
   }
 };
 
-export const getPreviewerFullUrl = (env: string, pubId: string, api: string, print?: boolean) => {
+export const getPreviewerFullUrl = (env: string, pubId: string, api: string, print?: boolean, prId?: string) => {
   const path = `/?publicationId=${pubId}&api=${api}${print ? '&_print_=1' : ''}`;
-  return `${getPreviewerRootUrl(env)}${path}`;
+  return `${getPreviewerRootUrl(env, prId)}${path}`;
 };
 
-export const getItemPreviewerFullUrl = (env: string, itemId: string, compositionId: string, api: string, screenshotHeight = 840) => {
+export const getItemPreviewerFullUrl = (env: string, itemId: string, compositionId: string, api: string, screenshotHeight = 840, prId?: string) => {
   const path = `/?itemId=${itemId}&compositionId=${compositionId}&_screenshots_=1&screenheight=${screenshotHeight}&api=${api}`;
-  return `${getPreviewerRootUrl(env)}${path}`;
+  return `${getPreviewerRootUrl(env, prId)}${path}`;
 };
 
 // dashboard
-
-export const getDashboardRootUrl = (env: string) => {
+export const getDashboardRootUrl = (env: string, prId?: string) => {
   switch (env) {
     case DEFAULT:
       return DEFAULT;
@@ -86,35 +75,26 @@ export const getDashboardRootUrl = (env: string) => {
     case Env.BETA:
       return `https://app-beta.foleon.com`;
     case Env.RELEASE:
-      return `https://app.foleon.dev`;
+      return `https://app-release.foleon.dev`;
     case Env.RELEASE_BETA:
       return `https://app-beta.foleon.dev`;
-
-    case Env.ACCEPTANCE_CLOUD:
-      return `https://app.acceptance.foleon.cloud`;
-    case Env.STAGING_CLOUD:
-      return `https://app.staging.foleon.cloud`;
-
+    case Env.PR:
+      return `https://${prId}-app.qa.staging.foleon.cloud`;
     default:
-      return `https://app-${env}.foleon.dev`;
+      return `https://app.${env}.foleon.cloud`;
   }
 };
 
-export const getDashboardFullUrl = (env: string) => getDashboardRootUrl(env);
+export const getDashboardFullUrl = getDashboardRootUrl;
 
 // api
-
 export const getApiUrl = (api: string) => {
   switch (api) {
     case DEFAULT:
       return DEFAULT;
     case Api.PRODUCTION:
       return `https://api.foleon.com`;
-    case Api.ACCEPTANCE_CLOUD:
-      return `https://api.acceptance.foleon.cloud`;
-    case Api.STAGING_CLOUD:
-      return `https://api.staging.foleon.cloud`;
     default:
-      return `https://api-${api}.foleon.dev`;
+      return `https://api.${api}.foleon.cloud`;
   }
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export const DIVIDER = '-';
 export const LOCALHOST = 'localhost';
 
 export enum LsKeys {
-  OW_DATA = 'owData',
+  NEW_TAB_DATA = 'newTabData',
   FAV_DATA = 'favData',
   ADDITIONAL_ENVS = 'additionalEnvs',
   LOCALHOST_EDITOR_PORT = 'localhostEditorPort',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export interface Info {
   app?: App;
   env?: string;
+  prId?: string;
   pubId?: string;
   pageId?: string;
   overlayId?: string;
@@ -13,9 +14,7 @@ export type UpdateProperties = chrome.tabs.UpdateProperties;
 export enum Api {
   PRODUCTION = 'production',
   ACCEPTANCE = 'acceptance',
-  ACCEPTANCE_CLOUD = 'acceptance cloud',
   STAGING = 'staging',
-  STAGING_CLOUD = 'staging cloud',
 }
 
 export enum Env {
@@ -24,9 +23,8 @@ export enum Env {
   RELEASE = 'release',
   RELEASE_BETA = 'release beta',
   ACCEPTANCE = 'acceptance',
-  ACCEPTANCE_CLOUD = 'acceptance cloud',
   STAGING = 'staging',
-  STAGING_CLOUD = 'staging cloud',
+  PR = 'PR',
 }
 
 export enum App {

--- a/src/ui/flags.ts
+++ b/src/ui/flags.ts
@@ -5,6 +5,7 @@ import { renderOption } from './tools';
 import { getApiUrl, getPreviewerRootUrl } from '../services/urls';
 import { additionalEnvs, apiKeys, apis, defaultEnvs, getLsData, flagsKeys, getInfo } from '../services/data';
 import { getActiveTab, reloadTab, sendMsgToActiveTab } from '../services/chrome';
+import { FLAGS } from '../extensionFlags';
 
 const $api = $('#api');
 const $previewBtn = $('#previewBtn');
@@ -19,7 +20,7 @@ const renderApisUI = () => {
 };
 
 const renderPreviewerEnvsUI = () => {
-  const envs = [DEFAULT, DIVIDER, ...defaultEnvs, DIVIDER, ...additionalEnvs];
+  const envs = [DEFAULT, DIVIDER, ...defaultEnvs, ...(FLAGS.SHOW_NAMED_ENVS ? [DIVIDER, ...additionalEnvs] : [])];
   const ui = envs.map((env) => renderOption(env, `<option value="${getPreviewerRootUrl(env)}">${env}</option>`)).join('');
   $previewer.html(ui);
 };

--- a/src/ui/info.ts
+++ b/src/ui/info.ts
@@ -4,16 +4,18 @@ import { getInfo } from '../services/data';
 
 const $info = $('#info');
 
-const renderInfo = (infoName: string, infoValue: string) => (infoValue ? `<span>${infoName}:</span> ${infoValue}<br />` : '');
+const renderInfo = (infoName: string, infoValue: string, newLine = true) =>
+  infoValue ? `<span>${infoName}:</span> ${infoValue}${newLine ? '<br />' : ', '}` : '';
 
 const renderInfoUI = () => {
   const info = getInfo();
   console.log(info);
   const ui = `
     ${renderInfo('application', info.app)}
-    ${renderInfo('env', info.env)}
+    ${renderInfo('env', info.env, !Boolean(info.prId))}
+    ${renderInfo('PR id', info.prId)}
     ${renderInfo('pub name', info.pubName)}
-    ${renderInfo('pub id', info.pubId)}
+    ${renderInfo('pub id', info.pubId, false)}
     ${renderInfo('page id', info.pageId)}`;
   $info.html(ui);
 };

--- a/src/ui/newTab.ts
+++ b/src/ui/newTab.ts
@@ -8,7 +8,7 @@ import { additionalEnvs, apis, defaultEnvs, getInfo } from '../services/data';
 import { createTab, getActiveTab, updateTab } from '../services/chrome';
 import { FLAGS } from '../extensionFlags';
 
-type OwData = {
+type NewTabData = {
   app: string;
   env: string;
   api: string;
@@ -21,26 +21,26 @@ const showRow = ($el: Cash) => $el.closest('p').show();
 const hideRows = (rowArray: Cash[]) => rowArray.map(hideRow);
 const showRows = (rowArray: Cash[]) => rowArray.map(showRow);
 
-const getOwData = () => (lsGet(LsKeys.OW_DATA) || {}) as OwData;
-const setOwData = (owData: OwData) => lsSet(LsKeys.OW_DATA, owData);
+const getNewTabData = () => (lsGet(LsKeys.NEW_TAB_DATA) || {}) as NewTabData;
+const setNewTabData = (newTabData: NewTabData) => lsSet(LsKeys.NEW_TAB_DATA, newTabData);
 
-const $owApp = $('#owApp');
-const $owEnv = $('#owEnv');
+const $newTabApp = $('#newTabApp');
+const $newTabEnv = $('#newTabEnv');
 //----- fields depending on selected app -------
-const $owPublicationId = $('#owPublicationId');
-const $owPageId = $('#owPageId');
-const $owOverlayId = $('#owOverlayId');
-const $owItemId = $('#owItemId');
-const $owCompositionId = $('#owCompositionId');
-const $owApi = $('#owApi');
-const $owPrint = $('#owPrint');
-const $owOpen = $('#owOpen');
-const $owPrId = $('#owPrId');
+const $newTabPublicationId = $('#newTabPublicationId');
+const $newTabPageId = $('#newTabPageId');
+const $newTabOverlayId = $('#newTabOverlayId');
+const $newTabItemId = $('#newTabItemId');
+const $newTabCompositionId = $('#newTabCompositionId');
+const $newTabApi = $('#newTabApi');
+const $newTabPrint = $('#newTabPrint');
+const $newTabOpen = $('#newTabOpen');
+const $newTabPrId = $('#newTabPrId');
 
-const $owOpenMore = $('#owOpenMore');
-const $owMoreWrap = $('#owMoreWrap');
-const $owMoreShowUrl = $('#owMoreShowUrl');
-const $owMoreThisTab = $('#owMoreThisTab');
+const $newTabOpenMore = $('#newTabOpenMore');
+const $newTabMoreWrap = $('#newTabMoreWrap');
+const $newTabMoreShowUrl = $('#newTabMoreShowUrl');
+const $newTabMoreThisTab = $('#newTabMoreThisTab');
 
 const getAppOptions = (currentApp: App): App[] => {
   switch (currentApp) {
@@ -58,36 +58,36 @@ const renderAppOptionsUI = (currentApp: App) => {
   const appOptions = getAppOptions(currentApp);
 
   const ui = appOptions.map((appOption, index) => renderOption(appOption)).join('');
-  $owApp.html(ui);
+  $newTabApp.html(ui);
 };
 
-const renderOwEnvEnvsUI = () => {
+const renderNewTabEnvsUI = () => {
   const envs: string[] = [...defaultEnvs, DIVIDER, ...(FLAGS.SHOW_NAMED_ENVS ? [additionalEnvs, DIVIDER] : []), LOCALHOST];
   const ui = envs.map((env) => renderOption(env)).join('');
-  $owEnv.html(ui);
+  $newTabEnv.html(ui);
 };
 
 const renderApisUI = () => {
   const ui = apis.map((api) => renderOption(api, `<option value="${getApiUrl(api)}">${api}</option>`)).join('');
-  $owApi.html(ui);
+  $newTabApi.html(ui);
 };
 
-const setOwDataUI = (info: Info) => {
-  const owData = getOwData();
+const setNewTabDataUI = (info: Info) => {
+  const newTabData = getNewTabData();
   const possibleApps = getAppOptions(info.app);
   const firstPossibleApp = possibleApps.length > 0 && possibleApps[0];
-  $owApp.val(possibleApps.includes(owData.app as App) ? owData.app : possibleApps.includes(info.app) ? info.app : firstPossibleApp);
-  $owEnv.val(owData.env || Env.ACCEPTANCE);
-  $owPrId.val(owData.prId || info.prId);
-  $owPublicationId.val(info.pubId);
-  $owPageId.val(info.pageId);
-  $owOverlayId.val(info.overlayId);
-  $owApi.val(owData.api || getApiUrl(Api.ACCEPTANCE));
-  $owPrint.prop('checked', !!owData.print || false);
+  $newTabApp.val(possibleApps.includes(newTabData.app as App) ? newTabData.app : possibleApps.includes(info.app) ? info.app : firstPossibleApp);
+  $newTabEnv.val(newTabData.env || Env.ACCEPTANCE);
+  $newTabPrId.val(newTabData.prId || info.prId);
+  $newTabPublicationId.val(info.pubId);
+  $newTabPageId.val(info.pageId);
+  $newTabOverlayId.val(info.overlayId);
+  $newTabApi.val(newTabData.api || getApiUrl(Api.ACCEPTANCE));
+  $newTabPrint.prop('checked', !!newTabData.print || false);
 };
 
 const hideMoreWrapHandler = () => {
-  $owMoreWrap.addClass('h');
+  $newTabMoreWrap.addClass('h');
   document.removeEventListener('click', hideMoreWrapHandler);
 };
 
@@ -95,66 +95,66 @@ export const initOpen = () => {
   const info = getInfo();
 
   renderAppOptionsUI(info.app);
-  renderOwEnvEnvsUI();
+  renderNewTabEnvsUI();
   renderApisUI();
 
-  setOwDataUI(info);
+  setNewTabDataUI(info);
 
-  $owApp
+  $newTabApp
     .on('change', () => {
-      const app = $owApp.val();
+      const app = $newTabApp.val();
       switch (app) {
         case App.PREVIEWER:
-          hideRows([$owPageId, $owOverlayId, $owItemId, $owCompositionId]);
-          showRows([$owPublicationId, $owApi, $owPrint]);
+          hideRows([$newTabPageId, $newTabOverlayId, $newTabItemId, $newTabCompositionId]);
+          showRows([$newTabPublicationId, $newTabApi, $newTabPrint]);
           break;
         case App.ITEM_PREVIEWER:
-          hideRows([$owPublicationId, $owPageId, $owOverlayId, $owPrint]);
-          showRows([$owItemId, $owCompositionId, $owApi]);
+          hideRows([$newTabPublicationId, $newTabPageId, $newTabOverlayId, $newTabPrint]);
+          showRows([$newTabItemId, $newTabCompositionId, $newTabApi]);
           break;
         case App.EDITOR:
-          hideRows([$owItemId, $owCompositionId, $owApi, $owPrint]);
-          showRows([$owPublicationId, $owPageId, $owOverlayId]);
+          hideRows([$newTabItemId, $newTabCompositionId, $newTabApi, $newTabPrint]);
+          showRows([$newTabPublicationId, $newTabPageId, $newTabOverlayId]);
           break;
         default:
           //DASHBOARD
-          hideRows([$owPageId, $owPublicationId, $owOverlayId, $owItemId, $owCompositionId, $owApi, $owPrint]);
+          hideRows([$newTabPageId, $newTabPublicationId, $newTabOverlayId, $newTabItemId, $newTabCompositionId, $newTabApi, $newTabPrint]);
           break;
       }
 
       // these fields will be hidden for now (looks like they will not be neccessary)
       // TODO: remove these fields (from popup.html and this file) if they are not needed after some time
       if (!FLAGS.SHOW_ADDITIONAL_FIELDS) {
-        hideRows([$owPublicationId, $owPageId, $owOverlayId]);
+        hideRows([$newTabPublicationId, $newTabPageId, $newTabOverlayId]);
       }
     })
     .trigger('change');
 
-  $owEnv
+  $newTabEnv
     .on('change', () => {
-      const env = $owEnv.val();
+      const env = $newTabEnv.val();
       switch (env) {
         case Env.PR:
-          showRows([$owPrId]);
+          showRows([$newTabPrId]);
           break;
         default:
-          hideRows([$owPrId]);
+          hideRows([$newTabPrId]);
           break;
       }
     })
     .trigger('change');
 
   const getOpenUrl = () => {
-    const app = $owApp.val() as string;
-    const env = $owEnv.val() as string;
-    const api = $owApi.val() as string;
-    const prId = $owPrId.val() as string;
-    const publicationId = $owPublicationId.val() as string;
-    const pageId = $owPageId.val() as string;
-    const overlayId = $owOverlayId.val() as string;
-    const itemId = $owItemId.val() as string;
-    const compositionId = $owCompositionId.val() as string;
-    const print = $owPrint.prop('checked');
+    const app = $newTabApp.val() as string;
+    const env = $newTabEnv.val() as string;
+    const api = $newTabApi.val() as string;
+    const prId = $newTabPrId.val() as string;
+    const publicationId = $newTabPublicationId.val() as string;
+    const pageId = $newTabPageId.val() as string;
+    const overlayId = $newTabOverlayId.val() as string;
+    const itemId = $newTabItemId.val() as string;
+    const compositionId = $newTabCompositionId.val() as string;
+    const print = $newTabPrint.prop('checked');
 
     let url = '';
 
@@ -168,27 +168,27 @@ export const initOpen = () => {
       url = getDashboardFullUrl(env, prId);
     }
 
-    setOwData({ app, env, api, prId, print });
+    setNewTabData({ app, env, api, prId, print });
 
     return url;
   };
 
-  $owOpen.on('click', () => {
+  $newTabOpen.on('click', () => {
     const url = getOpenUrl();
     createTab({ url, active: true });
     window.close();
   });
 
-  $owOpenMore.on('click', () => {
-    $owMoreWrap.removeClass('h');
+  $newTabOpenMore.on('click', () => {
+    $newTabMoreWrap.removeClass('h');
     document.addEventListener('click', hideMoreWrapHandler, true);
   });
 
-  $owMoreShowUrl.on('click', () => {
+  $newTabMoreShowUrl.on('click', () => {
     alert(getOpenUrl());
   });
 
-  $owMoreThisTab.on('click', () => {
+  $newTabMoreThisTab.on('click', () => {
     getActiveTab((activeTab) => {
       updateTab(activeTab.id, { url: getOpenUrl() });
       window.close();

--- a/src/ui/settings.ts
+++ b/src/ui/settings.ts
@@ -1,6 +1,7 @@
 import $ from 'cash-dom';
+import { FLAGS } from '../extensionFlags';
 
-import { additionalEnvs, localhostDashboardPort, localhostEditorPort, localhostPreviewerPort } from '../services/data';
+import { additionalEnvs, flagsKeys, localhostDashboardPort, localhostEditorPort, localhostPreviewerPort } from '../services/data';
 import { lsSet } from '../services/ls';
 import { LsKeys } from '../types';
 import { showMainSection, showSettingsSection } from './tools';
@@ -17,6 +18,10 @@ const $settDashboardPort = $('#settDashboardPort');
 const $settSave = $('#settSave');
 
 export const initSettings = () => {
+  if (!FLAGS.SHOW_NAMED_ENVS) {
+    $settAdditionalEnvs.parent().hide();
+  }
+
   $settAdditionalEnvs.val(additionalEnvs.join(envsJoiner));
   $settEditorPort.val(localhostEditorPort);
   $settPreviewerPort.val(localhostPreviewerPort);


### PR DESCRIPTION
What has been done:
  - extension is now recognizing PR environments
  - added new field `PR id` in new tab section
  - removed old staging and acceptance dev environments
  - created file for flags
  - flagged named environments
  - flagged unnecessary fields
  - fixed issue where release environments would go to `app.foleon.dev` instead of `app-release.foleon.dev` (same for other apps)
  - fixed issue where `App` default value in new tab section was not taken from local storage
  - renamed 'ow...' variables, ids, etc. to 'newTab...'